### PR TITLE
fix markdown in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Manchester Baby (Small Scale Experimental Machine)
 
 The [Manchester Small Scale Experimental Machine](https://en.wikipedia.org/wiki/Manchester_Small-Scale_Experimental_Machine) was the worlds first computer capable of executing a stored program.  The 32-bit architecture utilised an instruction set using only 3 bits allowing 8 possible instructions.  The program was stored in 32 memory locations (or store lines) with both data and program sharing storage (von Neumann architecture).
 
-##Python Emulator
+## Python Emulator
 
 The Python Emulator implements a simplified version of the Manchester Baby.  The main program is able to read simple assembler files and execute the programs contained.  The program displays the status of the machine at the start and end of the program run.


### PR DESCRIPTION
The sub-heading was not formatted as presumably intended.